### PR TITLE
Add Markstream Svelte resource

### DIFF
--- a/resources.json
+++ b/resources.json
@@ -810,5 +810,9 @@
   {
     "owner": "selfagency",
     "name": "stately"
+  },
+  {
+    "owner": "Simon-He95",
+    "name": "markstream-vue"
   }
 ]


### PR DESCRIPTION
## Summary

Adds Markstream to the Svelte resources directory.

Markstream provides an MIT-licensed Svelte/SvelteKit component package for rendering incomplete Markdown during streaming AI-chat or LLM responses, with Mermaid, KaTeX, streaming code blocks, SSR, and safe HTML.

- Svelte demo: https://markstream-svelte.pages.dev/
- Documentation: https://markstream.simonhe.me/frameworks/svelte
- Source: https://github.com/Simon-He95/markstream-vue

Thank you for considering it.
